### PR TITLE
using service module to enable slurm/munge to restart on machine reboot

### DIFF
--- a/roles/munge/tasks/front.yaml
+++ b/roles/munge/tasks/front.yaml
@@ -25,4 +25,4 @@
     when: not munge_key.stat.exists or munge_key_password != ''
 
   - name: Start munge service
-    service: name=munge state=started
+    service: name=munge enabled=yes state=started

--- a/roles/munge/tasks/wn.yaml
+++ b/roles/munge/tasks/wn.yaml
@@ -13,7 +13,7 @@
     when: not munge_key.stat.exists
 
   - name: Make sure the munge service is started
-    service: name=munge state=started
+    service: name=munge enabled=yes state=started
 
   - name: remove the local copy of the munge key file
     local_action: command rm -f "{{ local_munge_key }}"

--- a/roles/slurm/tasks/front.yaml
+++ b/roles/slurm/tasks/front.yaml
@@ -5,14 +5,17 @@
   - name: Include slurm config recipe
     include: "config_file.yaml"
 
-  - name: Start SLURM service
-    become: true
-    become_user: slurm
-    command: slurmctld
+  - name: Start SLURM service in front node
+    service:
+      name: slurmctld
+      enabled: yes
+      state: restarted
 
   - name: Ensure slurmd is not running in front node
-    shell: pgrep slurmd && killall slurmd
-    ignore_errors: yes
+    service:
+      name: slurmd
+      enabled: no
+      state: stopped
 
   - name: Reconfigure SLURM
     become: true

--- a/roles/slurm/tasks/wn.yaml
+++ b/roles/slurm/tasks/wn.yaml
@@ -7,8 +7,17 @@
   - name: Include slurm config recipe
     include: "config_file.yaml"
 
-  - name: Start Slurm Daemon
-    command: slurmd
+  - name: Start Slurm Daemon in worker node
+    service:
+      name: slurmd
+      enabled: yes
+      state: restarted
+
+  - name: Ensure slurmctld is not running in worker node
+    service:
+      name: slurmctld
+      enabled: no
+      state: stopped
 
   - name: Reconfigure SLURM
     command: scontrol reconfigure


### PR DESCRIPTION
... title says it already.

Check with:
```
$ vagrant ssh slurmmaster  # or slurmbatch1
$ systemctl list-unit-files | grep -i slurm
$ systemctl list-unit-files | grep -i munge
```