### PR TITLE
added conn_test role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -18,3 +18,10 @@
   roles:
     - name: slurm
       slurm_type_of_node: 'wn'
+  post_tasks:
+    - name: Test network connectivity
+      include_role:
+        name: conn_test
+      tags:
+        - slurm
+        - conn_test

--- a/roles/conn_test/tasks/main.yml
+++ b/roles/conn_test/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+  # some code parts taken from role ryandaniels.connectivity_test
+  # https://galaxy.ansible.com/ryandaniels/connectivity_test
+
+  - block:
+
+    - name: Install dependent packages in RedHat based machines
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+      - nc
+      when: ansible_os_family == "RedHat"
+
+    - debug:
+        msg:
+          - Test connectivity between slurm master {{ slurm_server_ip }} and worker node {{ inventory_hostname }}.
+        verbosity: 1
+
+    - name: Test connectivity slurm worker to master
+      command: "nc -zv {{ slurm_server_ip }} 6817"
+      delegate_to: "{{ inventory_hostname }}"
+
+    - name: Test connectivity slurm master to worker
+      command: "nc -zv {{ inventory_hostname }} 6818"
+      delegate_to: "{{ slurm_server_ip }}"
+    tags:
+      - slurm
+      - conn_test


### PR DESCRIPTION
This PR adds a role to check the network connectivity between slurm master and workers. It is called in `post_tasks` of the worker node. It installs and uses `netcat`. Can be run standalone by using the `conn_test` tag.

See also:
https://galaxy.ansible.com/ryandaniels/connectivity_test